### PR TITLE
updated links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ArcGIS-REST-API
-[Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop/related?hl=en) collection for [ArcGIS REST API ](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r300000054000000)
+[Postman](https://www.getpostman.com/apps) collection for [ArcGIS REST API](https://developers.arcgis.com/rest/)
 
-**Requirements**: [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop/related?hl=en)
+**Requirements**: [Postman](https://www.getpostman.com/apps)
 
 ## Auto import
 [![Importar colección a Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/collections/a5209ab41b8cae254074)


### PR DESCRIPTION
linking directly to postman website since the chrome app is being deprecated (http://blog.getpostman.com/2017/11/01/goodbye-postman-chrome-app/)